### PR TITLE
Sleep for longer at start of each test run.

### DIFF
--- a/test/integ/ezrassor_joy_translator/test_joy_translator.py
+++ b/test/integ/ezrassor_joy_translator/test_joy_translator.py
@@ -23,8 +23,6 @@ BACK_DRUM_ACTIONS_TOPIC = "back_drum_actions"
 ROUTINE_ACTIONS_TOPIC = "routine_actions"
 JOY_TOPIC = "joy"
 QUEUE_SIZE = 10
-LONG_CATCHUP_TIME = 1.0
-SHORT_CATCHUP_TIME = 0.1
 TIMEOUT = 2.0
 
 
@@ -218,7 +216,7 @@ class JoyTranslatorIntegrationTests(unittest.TestCase):
         )
 
         # Sleep for some time to give ROS a moment to warm up.
-        time.sleep(LONG_CATCHUP_TIME)
+        time.sleep(TIMEOUT)
 
     def tearDown(self):
         """Destroy testing infrastructure after each test.
@@ -240,8 +238,6 @@ class JoyTranslatorIntegrationTests(unittest.TestCase):
         message = sensor_msgs.msg.Joy()
         message.axes, message.buttons = raw_message
         self._joy_publisher.publish(message)
-        rclpy.spin_once(self._node, timeout_sec=TIMEOUT)
-        time.sleep(SHORT_CATCHUP_TIME)
 
     def _spin_for_subscribers(self):
         """Spin the node for a brief period of time.
@@ -250,7 +246,7 @@ class JoyTranslatorIntegrationTests(unittest.TestCase):
         collect all required outputs.
         """
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(time.sleep, LONG_CATCHUP_TIME)
+            future = executor.submit(time.sleep, TIMEOUT)
             rclpy.spin_until_future_complete(
                 self._node,
                 future,


### PR DESCRIPTION
Also stopped sleeping and spinning after publishing. Publishing is
instant and does not require a spin. Finally increased the length of
time used to spin for subscribers to give more time on the GitHub action
runner.